### PR TITLE
yocto: added support yocto sdk build

### DIFF
--- a/CT/Makefile
+++ b/CT/Makefile
@@ -5,8 +5,8 @@ CC       ?= gcc
 CXX      ?= g++
 DEFINES  = -DAPP_VERSION=\"1.5.6.516\"
 CFLAGS   += -g -Wall $(DEFINES) -pthread -fexceptions
-CXXFLAGS = $(CFLAGS) -Weffc++ $(DEFINES) -pthread -fexceptions
-LIBS     = -lm -lCTBase -lSiSProcedure -lSiSLog -lSiSExpressionLib -lSiSDeviceIO -L../lib -static
+CXXFLAGS = $(CFLAGS) -Weffc++ $(DEFINES) -pthread -fexceptions -L../lib
+LIBS     = -lm -lCTBase -lSiSProcedure -lSiSLog -lSiSExpressionLib -lSiSDeviceIO
 INCPATH  = -I. -I../SiSLog -I../SiSExpressionLib -I../SiSDeviceIO -I../SiSProcedure -I../CTBase -I../CTBase/getFirmwareId -I../CTBase/updateFW -I../CTBase/getFirmwareInfo
 DIR      = $(shell pwd)
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Requirement
         * SDK
         * NDK
         * eclipse (optional)
+    4. Yocto SDK
+        downlaod and install Yocto SDK
+        https://drive.google.com/file/d/1tu3uZDmJ5V4szkXpgja05D6zrZ-gqPg0/view?usp=sharing
 
 Compilation
 ---

--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
-Requirement
----
-    1. Linux x86 or x86_64 platform
-    2. Java
-        * JDK 6 (JRE alone is not sufficient)
-        * Apache Ant 1.8 or later
-    3. Android Developer Tool Kit (http://developer.android.com/sdk/index.html)
-        * SDK
-        * NDK
-        * eclipse (optional)
-    4. Yocto SDK
-        downlaod and install Yocto SDK
-        https://drive.google.com/file/d/1tu3uZDmJ5V4szkXpgja05D6zrZ-gqPg0/view?usp=sharing
+System requirement
+- Ubuntu 14.04 or higher
+- [Yocto SDK](https://drive.google.com/file/d/1tu3uZDmJ5V4szkXpgja05D6zrZ-gqPg0/view?usp=sharing)
 
-Compilation
----
-    Just type 'make' on the root directory os this projecct
-    $ make
+Setup SDK
+```
+run sdk installation script
+set build environment by 
+. ./environment-setup-cortexa9hf-neon-poky-linux-gnueabi
+```
+Make SiS tool
+```
+    make
+```
+Parameters
+```
+    -ba 
+    -n=<i2c deivce node>
+    -n=/dev/sis_hydra_touch_device 
+    -io-interval=<milliseconds dealy>
+    -io-interval=2
+    -debug
+```

--- a/SiSDeviceIO/sisdeviceio/impl/819/isisdeviceio_819_i2c.cpp
+++ b/SiSDeviceIO/sisdeviceio/impl/819/isisdeviceio_819_i2c.cpp
@@ -37,7 +37,7 @@ ISiSDeviceIO_819_i2c::burnToROM(unsigned int address, int size, unsigned char* b
 
     while ( sendLegnth < size )
     {
-        unsigned int blockSize = size > sendLegnth + __8K ? __8K : size - sendLegnth;
+        unsigned int blockSize = size > sendLegnth + __4K ? __4K : size - sendLegnth;
         sendLegnth += blockSize;
 
         int pageNum = blockSize / dataLength + (blockSize % dataLength == 0 ? 0 : 1 );

--- a/SiSDeviceIO/sisdeviceio/impl/819/isisdeviceio_819_i2c.h
+++ b/SiSDeviceIO/sisdeviceio/impl/819/isisdeviceio_819_i2c.h
@@ -18,6 +18,7 @@
 #define PAGE_SIZE 256
 #define __12K 0x3000
 #define __8K 0x2000
+#define __4K 0x1000
 
 /* cmd info */
 #define DATA_86_UNIT_64 52

--- a/SiSDeviceIO/sisdeviceio/impl/819/sisdeviceio_819_hid_over_i2c.cpp
+++ b/SiSDeviceIO/sisdeviceio/impl/819/sisdeviceio_819_hid_over_i2c.cpp
@@ -47,7 +47,7 @@
 
 #include <errno.h>
 
-#define OUTPUT_IGNORE 4
+#define OUTPUT_IGNORE 0
 
 //HEADER_LENGTH is the byte count before Length field
 #define BEFORE_LENGTH_FIELD_BYTES 2

--- a/SiSDeviceIO/sisdeviceio/impl/819/sisdeviceio_819_hid_over_i2c.cpp
+++ b/SiSDeviceIO/sisdeviceio/impl/819/sisdeviceio_819_hid_over_i2c.cpp
@@ -231,17 +231,19 @@ SiSDeviceIO_819_hid_over_i2c::readData( unsigned char * buf, int size, int timeo
 
         if( ret > 0 )
         {
+            // The default use getReportIdIndex(false) and don't need
+            // add extra byte0 and byte1.
             /* insert byte0(Length field LSB) and byte1(Length field MSB) */
-            ret += 2;
-            char lengthLSB = ret & 0xff;
-            char lengthMSB = (ret >> 8) & 0xff;
-		
-            for(int i = ret - 1; i > 1; i--)
-            {
-                buf[i] = buf[i - 2];
-            }
-            buf[0] = lengthLSB;
-            buf[1] = lengthMSB;
+            // ret += 2;
+            // char lengthLSB = ret & 0xff;
+            // char lengthMSB = (ret >> 8) & 0xff;
+        
+            // for(int i = ret - 1; i > 1; i--)
+            // {
+            //     buf[i] = buf[i - 2];
+            // }
+            // buf[0] = lengthLSB;
+            // buf[1] = lengthMSB;
             /* --- */
         }
     }

--- a/SiSDeviceIO/sisdevicemgr/sisdevicemgr.cpp
+++ b/SiSDeviceIO/sisdevicemgr/sisdevicemgr.cpp
@@ -51,7 +51,7 @@ using namespace SiS;
 
 /* SiS device node name */
 #define SIS_TOUCH_USB_HIDRAW "/dev/sis_touch_usb_hidraw"
-#define SIS_TOUCH_I2C_HIDRAW "/dev/sis_touch_i2c_hidraw"
+#define SIS_TOUCH_I2C_HIDRAW "/dev/sis_hydra_touch_device"
 //----------------------
 
 SiSDeviceMgr::SiSDeviceMgr() :


### PR DESCRIPTION
Hello Jason,
I am helping check sis tools on Yocot, and link shared libs cannot be found happen because of "-static". 
And since you already assign static library path and thus use "-static" is not necessary.

removed link shared libs with "-static" that lead to libs cannot be found

Thanks,
Karl